### PR TITLE
fix: use canonical go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ory/sdk
+module github.com/ory/kratos-client-go
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ory/kratos-client-go
+module github.com/aaronong/kratos-client-go
 
 go 1.13
 


### PR DESCRIPTION
The client module is situated at `github.com/ory/kratos-client-go`, but the go mod currently publicizes the wrong location.